### PR TITLE
Solar authenticate

### DIFF
--- a/Custom Photo Frame/src/com/voidStudios/photoDisplay/Controller.java
+++ b/Custom Photo Frame/src/com/voidStudios/photoDisplay/Controller.java
@@ -26,7 +26,7 @@ public class Controller {
 
 		iDir=new ImageDirectory("photos", this);
 		weatherManager=new WeatherManager(sloader.getAPIKey(), sloader.getLat(), sloader.getLon());
-		energyManager=new EnergyManager(sloader.getIP());
+		energyManager=new EnergyManager(sloader.getIP(), sloader.getPassword());
 	}
 
 	public void pause() {

--- a/Custom Photo Frame/src/com/voidStudios/photoDisplay/EnergyManager.java
+++ b/Custom Photo Frame/src/com/voidStudios/photoDisplay/EnergyManager.java
@@ -55,7 +55,10 @@ public class EnergyManager {
 				return ret;
 			}catch(Exception e) {
 				//Check if server returns 403 unauthorized
-				if(e.getMessage().contains("Server returned HTTP response code: 403 for URL")) {
+				boolean is401=e.getMessage().contains("Server returned HTTP response code: 403 for URL");
+				//Check for 401, likely means cookies expired. Treat the same as a 403 (attempt to re-authenticate)
+				boolean is403=e.getMessage().contains("Server returned HTTP response code: 401 for URL");
+				if(is401 || is403) {
 					//Check if this is the second try
 					//(i.e. attempted to get a new cookie but server returned 403 still)
 					if(authRetry) {
@@ -160,7 +163,10 @@ public class EnergyManager {
 				for(String cookie : cookiesHeader) {
 					cManager.getCookieStore().add(null, HttpCookie.parse(cookie).get(0));
 				}
+				//System.out.println("COOKIE: Updated with "+cookiesHeader.size()+" cookies at "+new Date());
+				return;
 			}
+			System.out.println(new Date()+": Warning: Failed to update Powerwall authentication cookies");
 		}catch(Exception e) {
 			System.err.println(new Date()+": Warning: Failed to get authentication cookie with error: "+e.getMessage());
 		}

--- a/Custom Photo Frame/src/com/voidStudios/photoDisplay/EnergyManager.java
+++ b/Custom Photo Frame/src/com/voidStudios/photoDisplay/EnergyManager.java
@@ -2,6 +2,9 @@ package com.voidStudios.photoDisplay;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.CookieManager;
+import java.net.HttpCookie;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.KeyManagementException;
@@ -9,6 +12,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.text.DecimalFormat;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -19,52 +25,144 @@ import javax.net.ssl.X509TrustManager;
 
 public class EnergyManager {
 
+	private static final String COOKIES_HEADER="Set-Cookie";
+	private CookieManager cManager;
 	private String ip;
+	private String password;
 	private DecimalFormat df;
 
-	public EnergyManager(String ip) {
+	public EnergyManager(String ip, String password) {
 		this.ip=ip;
+		this.password=password;
 		df=new DecimalFormat("#0.0");
+		cManager=new CookieManager();
+		//Grab an initial authentication cookie
+		getAuthCookie();
 	}
 
+	/**
+	 * Fetches the instant_power from the Powerwall.
+	 * Potentially retries one additional time on a 403 failure, which tries to fetch a new authentication cookie.
+	 * Returns null on any error.
+	 * 
+	 * @return The current kW being produced by the solar array. 0 if less than .1kW. Null on error.
+	 */
 	public String getEnergy() {
+		boolean authRetry=false;
+		while(true) {
+			try {
+				String ret=getEnergyHelper();
+				return ret;
+			}catch(Exception e) {
+				//Check if server returns 403 unauthorized
+				if(e.getMessage().contains("Server returned HTTP response code: 403 for URL")) {
+					//Check if this is the second try
+					//(i.e. attempted to get a new cookie but server returned 403 still)
+					if(authRetry) {
+						System.err.println(new Date()+": Warning: Authentication failed: "+e.getMessage());
+						return null;
+					}
+					//Try and get a new authentication cookie
+					getAuthCookie();
+					authRetry=true;
+					continue;
+				}
+				//Something else went wrong (not an expected 403 return)
+				//Return null, log error
+				System.err.println(new Date()+": Warning: Failed to get energy with error: "+e.getMessage());
+				return null;
+			}
+		}
+	}
+
+	private String getEnergyHelper() throws Exception {
+		//Setup connection to Powerwall
+		URL url=new URL("https://"+ip+"/api/meters/solar");
+		HttpURLConnection httpCon=(HttpURLConnection) url.openConnection();
+		httpCon.setRequestMethod("GET");
+
+		//Ignore the self-signed SSL certificate
+		setAcceptAllVerifier((HttpsURLConnection) httpCon);
+
+		//Add cookies to request, if any
+		//This allows authentication with the Powerwall
+		if(cManager.getCookieStore().getCookies().size()>0) {
+			StringJoiner joiner=new StringJoiner(";");
+			for(HttpCookie c : cManager.getCookieStore().getCookies()) {
+				joiner.add(c.toString());
+			}
+			httpCon.setRequestProperty("Cookie", joiner.toString());
+		}
+
+		//Read Powerwall response
+		BufferedReader in=new BufferedReader(new InputStreamReader(httpCon.getInputStream()));
+		String inputLine;
+		StringBuffer content=new StringBuffer();
+		while((inputLine=in.readLine())!=null) {
+			content.append(inputLine);
+		}
+		in.close();
+
+		//Should probably JSON parse this instead of string searching
+		//Find instant_power, and skip to the actual value (+2)
+		int start=content.indexOf("instant_power")+"instant_power".length()+2;
+		String s=null;
+		//Extract the number, starting at start and ending at the first ',' after that
+		if(start!=-1) {
+			s=content.substring(start);
+			int end=s.indexOf(',');
+			s=s.substring(0, end);
+		}
+
+		//Convert to double and round
+		double kW=Double.parseDouble(s)/1000;
+		//If energy is negligible (less than 100 watts) return null
+		if(kW<.1)
+			return null;
+		return df.format(kW)+" kW";
+	}
+
+	/**
+	 * Fetches an authentication cookie from the Powerwall.
+	 * Version 20.49 of Powerwall software necessitated authentication for access to API calls.
+	 * Username differentiates between a customer sign in and a contractor sign in.
+	 * Email is presently not used for authentication, so a dummy email is presented.
+	 */
+	private void getAuthCookie() {
+		//Remove previous cookies
+		cManager.getCookieStore().removeAll();
+
 		try {
-			URL url;
-			url=new URL("https://"+ip+"/api/meters/solar");
+			//Setup connection to login page
+			URL url=new URL("https://"+ip+"/api/login/Basic");
 			HttpURLConnection httpCon=(HttpURLConnection) url.openConnection();
-			httpCon.setRequestMethod("GET");
+			httpCon.setRequestMethod("POST");
+			httpCon.setRequestProperty("Content-Type", "application/json; utf-8");
+			httpCon.setDoOutput(true);
 
 			//Ignore the self-signed SSL certificate
 			setAcceptAllVerifier((HttpsURLConnection) httpCon);
 
-			BufferedReader in=new BufferedReader(new InputStreamReader(httpCon.getInputStream()));
-			String inputLine;
-			StringBuffer content=new StringBuffer();
-			while((inputLine=in.readLine())!=null) {
-				content.append(inputLine);
-			}
-			in.close();
-
-			//Find instant_power, and skip to the actual value (+2)
-			int start=content.indexOf("instant_power")+"instant_power".length()+2;
-			String s=null;
-			//Extract the number, starting at start and ending at the first ',' after that
-			if(start!=-1) {
-				s=content.substring(start);
-				int end=s.indexOf(',');
-				s=s.substring(0, end);
+			//Send the data for authentication
+			String jsonInputString="{\"username\":\"customer\",\"password\":\""+password
+					+"\",\"email\":\"dummy@email.domain\",\"force_sm_off\":false}";
+			try(OutputStream os=httpCon.getOutputStream()) {
+				byte[] input=jsonInputString.getBytes("utf-8");
+				os.write(input, 0, input.length);
 			}
 
-			//Convert to double and round
-			double kW=Double.parseDouble(s)/1000;
-			//If energy is negligible (less than 100 watts) return null
-			if(kW<.1)
-				return null;
-			return df.format(kW)+" kW";
+			//Parse headers and extract cookies
+			Map<String, List<String>> headerFields=httpCon.getHeaderFields();
+			List<String> cookiesHeader=headerFields.get(COOKIES_HEADER);
+
+			//Load cookies to cookie manager
+			if(cookiesHeader!=null) {
+				for(String cookie : cookiesHeader) {
+					cManager.getCookieStore().add(null, HttpCookie.parse(cookie).get(0));
+				}
+			}
 		}catch(Exception e) {
-			//If anything went wrong return null
-			System.err.println(new Date()+": Warning: Failed to get energy");
-			return null;
+			System.err.println(new Date()+": Warning: Failed to get authentication cookie with error: "+e.getMessage());
 		}
 	}
 

--- a/Custom Photo Frame/src/com/voidStudios/photoDisplay/SettingsLoader.java
+++ b/Custom Photo Frame/src/com/voidStudios/photoDisplay/SettingsLoader.java
@@ -15,6 +15,7 @@ public class SettingsLoader {
 	private static final String DATE_DEFAULT="60";
 	private static final String ENERGY_DEFAULT="5";
 	private static final String IP_DEFAULT="127.0.0.1";
+	private static final String PASSWORD_DEFAULT="password";
 	private static final boolean ENABLE_DATE_DEFAULT=true;
 	private static final boolean PHOTO_CENTER_ALIGN=true;
 	private static final boolean ENABLE_ENERGY_DEFAULT=false;
@@ -134,6 +135,10 @@ public class SettingsLoader {
 
 	public String getIP() {
 		return props.getProperty("ip", IP_DEFAULT);
+	}
+
+	public String getPassword() {
+		return props.getProperty("password", PASSWORD_DEFAULT);
 	}
 
 }

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ Additional integration with a Tesla Powerwall is [available](#tesla-powerwall-in
 	1. The location of a config file
 
 ## Tesla Powerwall Integration
-**_IMPORTANT_: Functionality has been broken by Version 20.49**<br/>
-This update requires authentication to access the API page. I'm looking into how to obtain authentication to restore functionality.
 
-If you have a Powerwall (likely v2 required) which is configured to use your network as its primary connection type, its gateway can be used to retrieve the current power output of an attached solar installation. Visiting `<gateway-IP>/api/meters/solar` should display detailed information about the solar installation. My program specifically uses “instant_power,” which I understand to be the current wattage being produced. Adding the following to the config file will add a display for the current power output of the solar installation. If less than 100 watts are being produced, the energy display is hidden.
+If you have a Powerwall (likely v2 required) which is configured to use your network as its primary connection type, its gateway can be used to retrieve the current power output of an attached solar installation. After authenticating, visiting `<gateway-IP>/api/meters/solar` should display detailed information about the solar installation. My program specifically uses “instant_power,” which I understand to be the current wattage being produced. Adding the following to the config file will add a display for the current power output of the solar installation. If less than 100 watts are being produced, the energy display is hidden. As of version 20.49, authentication is required for access to the Powerwall API. Currently the email field is not used, so only the password needs to be given.
 	
 `enableEnergy=true` Enables the energy display
 <br/>
 `energyUpdate=1` Sets the energy update frequency in minutes
 <br/>
 `ip=<LOCAL-IP>` Sets the IP of the gateway
+<br/>
+`password=<POWERWALL-PASSWORD>` Sets the Password for authentication with the Powerwall
 
 <br/><br/>
 


### PR DESCRIPTION
Fixes an issue introduced by Powerwall version 20.49, which added the need to authenticate for access to Powerwall data. The software now authenticates properly with the Powerwall gateway, allowing solar power data to be displayed again.
An additional password field has been added to the config file.